### PR TITLE
グラフに全体の時間を表示するように変更

### DIFF
--- a/src/services/timelineService.ts
+++ b/src/services/timelineService.ts
@@ -97,13 +97,13 @@ const createChart = async (dailyLogs: DailyLog[]): Promise<Blob | null> => {
         .call(text => text.append("tspan")
             .attr("y", "-0.4em")
             .attr("font-weight", "bold")
-            .attr("font-size", "12px")  // Increase font size
+            .attr("font-size", "12px")
             .text(d => d.data.workKindName))
         .call(text => text.filter(d => (d.endAngle - d.startAngle) > 0.25).append("tspan")
             .attr("x", 0)
             .attr("y", "0.7em")
             .attr("fill-opacity", 0.7)
-            .attr("font-size", "12px")  // Increase font size
+            .attr("font-size", "12px")
             .text(d => d.data.comment));
 
     // 中央に合計時間を表示
@@ -112,7 +112,8 @@ const createChart = async (dailyLogs: DailyLog[]): Promise<Blob | null> => {
     const remainMinutes = Math.floor(totalMinutes % 60);
     svg.append("text")
         .attr("text-anchor", "middle")
-        .attr("font-size", "17px")  // Increase font size
+        .attr("font-size", "17px")
+        .attr("font-weight", "bold")
         .attr("y", 0)
         .text(`${Math.floor(totalHours)}h ${remainMinutes}m`);
 

--- a/src/services/timelineService.ts
+++ b/src/services/timelineService.ts
@@ -98,7 +98,7 @@ const createChart = async (dailyLogs: DailyLog[]): Promise<Blob | null> => {
             .attr("y", "-0.4em")
             .attr("font-weight", "bold")
             .attr("font-size", "12px")
-            .text(d => d.data.workKindName))
+            .text(d => d.data.workKindName + ' ' + (d.endAngle - d.startAngle) / (2 * Math.PI) * 100 + '%'))
         .call(text => text.filter(d => (d.endAngle - d.startAngle) > 0.25).append("tspan")
             .attr("x", 0)
             .attr("y", "0.7em")

--- a/src/services/timelineService.ts
+++ b/src/services/timelineService.ts
@@ -98,7 +98,7 @@ const createChart = async (dailyLogs: DailyLog[]): Promise<Blob | null> => {
             .attr("y", "-0.4em")
             .attr("font-weight", "bold")
             .attr("font-size", "12px")
-            .text(d => d.data.workKindName + ' ' + (d.endAngle - d.startAngle) / (2 * Math.PI) * 100 + '%'))
+            .text(d => d.data.workKindName + ' ' + Math.floor((d.endAngle - d.startAngle) / (2 * Math.PI) * 100) + '%'))
         .call(text => text.filter(d => (d.endAngle - d.startAngle) > 0.25).append("tspan")
             .attr("x", 0)
             .attr("y", "0.7em")

--- a/src/services/timelineService.ts
+++ b/src/services/timelineService.ts
@@ -109,10 +109,10 @@ const createChart = async (dailyLogs: DailyLog[]): Promise<Blob | null> => {
     // 中央に合計時間を表示
     const totalMinutes = dailyLogs.reduce((total, dailyLog) => total + dailyLog.timeDelta, 0);
     const totalHours = totalMinutes / 60;
-    const remainMinutes = totalMinutes % 60;
+    const remainMinutes = Math.floor(totalMinutes % 60);
     svg.append("text")
         .attr("text-anchor", "middle")
-        .attr("font-size", "12px")  // Increase font size
+        .attr("font-size", "17px")  // Increase font size
         .attr("y", 0)
         .text(`${Math.floor(totalHours)}h ${remainMinutes}m`);
 

--- a/src/services/timelineService.ts
+++ b/src/services/timelineService.ts
@@ -106,6 +106,16 @@ const createChart = async (dailyLogs: DailyLog[]): Promise<Blob | null> => {
             .attr("font-size", "12px")  // Increase font size
             .text(d => d.data.comment));
 
+    // 中央に合計時間を表示
+    const totalMinutes = dailyLogs.reduce((total, dailyLog) => total + dailyLog.timeDelta, 0);
+    const totalHours = totalMinutes / 60;
+    const remainMinutes = totalMinutes % 60;
+    svg.append("text")
+        .attr("text-anchor", "middle")
+        .attr("font-size", "12px")  // Increase font size
+        .attr("y", 0)
+        .text(`${Math.floor(totalHours)}h ${remainMinutes}m`);
+
     // Convert the SVG to a PNG image.
     const canvas = createCanvas(width, height);
     const context = canvas.getContext('2d');

--- a/src/services/timelineService.ts
+++ b/src/services/timelineService.ts
@@ -98,7 +98,7 @@ const createChart = async (dailyLogs: DailyLog[]): Promise<Blob | null> => {
             .attr("y", "-0.4em")
             .attr("font-weight", "bold")
             .attr("font-size", "12px")
-            .text(d => d.data.workKindName + ' ' + Math.floor((d.endAngle - d.startAngle) / (2 * Math.PI) * 100) + '%'))
+            .text(d => d.data.workKindName + ((d.endAngle - d.startAngle) > 0.25 ? ' ' + Math.floor((d.endAngle - d.startAngle) / (2 * Math.PI) * 100) + '%' : '')))
         .call(text => text.filter(d => (d.endAngle - d.startAngle) > 0.25).append("tspan")
             .attr("x", 0)
             .attr("y", "0.7em")

--- a/src/services/timelineService.ts
+++ b/src/services/timelineService.ts
@@ -98,7 +98,7 @@ const createChart = async (dailyLogs: DailyLog[]): Promise<Blob | null> => {
             .attr("y", "-0.4em")
             .attr("font-weight", "bold")
             .attr("font-size", "12px")
-            .text(d => d.data.workKindName + ((d.endAngle - d.startAngle) > 0.25 ? ' ' + Math.floor((d.endAngle - d.startAngle) / (2 * Math.PI) * 100) + '%' : '')))
+            .text(d => d.data.workKindName))
         .call(text => text.filter(d => (d.endAngle - d.startAngle) > 0.25).append("tspan")
             .attr("x", 0)
             .attr("y", "0.7em")

--- a/src/services/timelineService.ts
+++ b/src/services/timelineService.ts
@@ -112,7 +112,7 @@ const createChart = async (dailyLogs: DailyLog[]): Promise<Blob | null> => {
     const remainMinutes = Math.floor(totalMinutes % 60);
     svg.append("text")
         .attr("text-anchor", "middle")
-        .attr("font-size", "17px")
+        .attr("font-size", "20px")
         .attr("font-weight", "bold")
         .attr("y", 0)
         .text(`${String(Math.floor(totalHours)).padStart(2, '0')}h ${String(remainMinutes).padStart(2, '0')}m`);

--- a/src/services/timelineService.ts
+++ b/src/services/timelineService.ts
@@ -115,7 +115,7 @@ const createChart = async (dailyLogs: DailyLog[]): Promise<Blob | null> => {
         .attr("font-size", "17px")
         .attr("font-weight", "bold")
         .attr("y", 0)
-        .text(`${Math.floor(totalHours)}h ${remainMinutes}m`);
+        .text(`${String(Math.floor(totalHours)).padStart(2, '0')}h ${String(remainMinutes).padStart(2, '0')}m`);
 
     // Convert the SVG to a PNG image.
     const canvas = createCanvas(width, height);


### PR DESCRIPTION
This pull request includes a significant update to the `createChart` function in `src/services/timelineService.ts`. The most important change is the addition of code to display the total time in hours and minutes at the center of the chart. 

Changes to chart display:

* [`src/services/timelineService.ts`](diffhunk://#diff-aad093a27b773d88f00e1fa62da2cfa62e2d56d991c5cf65b1ec1df441be7673L100-R119): Added code to calculate the total time from `dailyLogs` and display it in the center of the chart in the format "hh:mm".